### PR TITLE
Fix: clearStore delete each keys instead of reassigning value entries Fixes #12

### DIFF
--- a/src/OfflineImageStore.js
+++ b/src/OfflineImageStore.js
@@ -86,7 +86,8 @@ class OfflineImageStore {
           console.log('Removed offline image store completely!');
         }
         // Empty all entries so that we should update offline Async storage
-        this.entries = {};
+        Object.keys(this.entries).forEach(key => delete this.entries[key]);
+
 
         // Update offline Async storage
         this._updateAsyncStorage(onRestoreCompletion);


### PR DESCRIPTION
Hello,

This PR fixes issue #12.

I replaced the reassignation of attribute entries by the deletion of each key in the same object.

The reassignation had no effect because the instance of OfflineImageStore is freezed before being export.


Regards,