### PR TITLE
Fix: clearStore fails when no image loaded yet

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,8 +213,9 @@ You can use a fallback image as a default image to show when unable to download 
 You can clear complete offline store at any point of time using 
 ```
 // Clean all the images
-OfflineImageStore.clearStore(() => {
-    console.log('Hurray!! clearStore completed callback called');
+OfflineImageStore.clearStore((err) => {
+    if (!err)
+      console.log('Hurray!! clearStore completed callback called');
 });
 ```  
 

--- a/src/OfflineImageStore.js
+++ b/src/OfflineImageStore.js
@@ -79,8 +79,17 @@ class OfflineImageStore {
    * Removes all the images in the offline store.
    */
   clearStore = (onRestoreCompletion) => {
-    // Remove from offline store
-    return RNFetchBlob.fs.unlink(this.getBaseDir())
+
+    // Check if the folder exists
+    return RNFetchBlob.fs.exists(this.getBaseDir())
+      .then((exists) => {
+        // If folder does not exists, no need to unlink it
+        if (!exists)
+          return;
+
+        // Remove from offline store
+        return RNFetchBlob.fs.unlink(this.getBaseDir())
+      })
       .then(() => { // On completion
         if (this.store.debugMode) {
           console.log('Removed offline image store completely!');
@@ -97,6 +106,9 @@ class OfflineImageStore {
         if (this.store.debugMode) {
           console.log('unable to remove offline store', err);
         }
+
+        // Call callback with the error
+        onRestoreCompletion(err);
       });
   };
 


### PR DESCRIPTION
Hello Team,

This PR fixes #16, opened by my friend. 

I check the existence of the folder before unlinking it.
Anyway, I still do the logic of cleaning after all.

Although, I think it's a good thing to call the callback with an error as param. If not, users of the library will see their apps frozen when having a random error. what do you think ?

Kind regards, 

Robin